### PR TITLE
docs: document additional key flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,24 @@ Key flags:
 - `--out` — write output to a file instead of stdout.
 - `--follow-symlinks` — resolve symlinks and include targets.
 - `--version` — print version and exit.
+- `--ext` — comma-separated list of file extensions to include (e.g. ".go,.md").
+- `--name-regex` — regular expression to match file or directory names.
+- `--min-size` / `--max-size` — include entries within a size range (e.g. "10KB", "2MB").
+- `--after` / `--before` — filter by modification time (YYYY-MM-DD or RFC3339).
+- `--include-hidden` — include hidden files and directories.
+- `--max-depth` — limit directory traversal depth (-1 for unlimited).
+- `--concurrency` — number of concurrent directory workers.
 
 Example:
 
 ```bash
+gofind --ext .go,.md
+gofind --name-regex 'test.*\\.go'
+gofind --min-size 10KB --max-size 2MB
+gofind --after 2024-01-01 --before 2024-02-01
+gofind --include-hidden
+gofind --max-depth 2
+gofind --concurrency 4
 gofind --root . --json --pretty
 ```
 


### PR DESCRIPTION
## Summary
- document extension, regex, size, time, visibility, depth, and concurrency flags in README
- add short usage examples for new flags

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b82ace1d1c8326bfba8a40177287a1