### PR TITLE
chore: remove go.mod backup file

### DIFF
--- a/go.mod.bak
+++ b/go.mod.bak
@@ -1,7 +1,0 @@
-module github.com/Hamed0406/gofind
-
-go 1.24.6
-
-require github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
-
-require github.com/stretchr/testify v1.10.0 // indirect


### PR DESCRIPTION
## Summary
- remove leftover go.mod.bak file from repository
- run `go mod tidy` to ensure `go.mod` and `go.sum` stay consistent

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b83a13965083268fbedbc1e7513bcf