### PR TITLE
Use Go 1.22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        go: ["1.24.x"]
+        go: ["1.22.x"]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -93,7 +93,7 @@ jobs:
       - name: Set up Go (match go.mod)
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.x'
+          go-version: '1.22.x'
           cache: true
 
       - name: Print Go env (debug)

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/Hamed0406/gofind
 
-go 1.24.6
+go 1.22


### PR DESCRIPTION
## Summary
- set go.mod go directive to 1.22
- align CI workflow to Go 1.22.x

## Testing
- `go mod tidy`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b83cd3d370832685145123c90078ee